### PR TITLE
change pyramid_config fixture scope to session - closes #50.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 CHANGES
 =======
 
+unreleased
+----------
+
+- [feature] changed pyramid_config fixture scope to session.
+
 0.2.0
 ----------
 

--- a/pytest_pyramid/factories.py
+++ b/pytest_pyramid/factories.py
@@ -30,7 +30,7 @@ def pyramid_config(settings=None, config_path=None):
     :returns: configuration
     :rtype: `pyramid.config.Configurator`
     """
-    @pytest.fixture
+    @pytest.fixture(scope='session')
     def pyramid_config(request):
         app_settings = settings
         if app_settings is None:


### PR DESCRIPTION
- it's not dynamic, so should not be affected by tests.