### PR TITLE
Add additional_fixtures argument to pyramid_app factory

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,3 +6,4 @@ of pytest_pyramid along its history.
 
 * Grzegorz Śliwiński
 * Eric Hulser
+* Łukasz Bieszczad

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 CHANGES
 =======
 
+unreleased
+----------
+
+- add additiona_fixtures to factories.pyramid_app
+
 0.3.2
 ----------
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,9 +1,9 @@
 Usage
 =====
 
-For the most basic usage pytest_pyramid provides a pyramid_app and pyramid_config fixtures,
+For the most basic usage, pytest_pyramid provides pyramid_app and pyramid_config fixtures,
 that can be used to test your pyramid app.
-Simply pass your pyramid config ***.ini** file to **--pc** command line option,
+Simply pass your pyramid config ***.ini** file to **--pc** command-line option,
 and include *pytest_app* fixture into your test suite to be able to use it for
 integration tests.
 
@@ -16,21 +16,30 @@ pytest_pyramid provides two fixtures to be used in pytest tests:
     defined in pyramid config's file
 * **pyramid_app** - pyramid application for testing - a :class:`webtest.app.TestApp`
 
-Both of these fixtures depend on Config file passed in command line.
+Both of these fixtures depend on the Config file passed in the command line.
 
 
 Fixture factories
 -----------------
 
 If you're developing a module, package meant to extend functionalities of other
-applications, it's not necessary to create a full blown application to test
+applications, it's not necessary to create a full-blown application to test
 functionalities provided in packages. To do this, **pytest_pyramid** provides
 you with fixture :mod:`~pytest_pyramid.factories`.
 
 There are two factories:
 
-* :func:`~pytest_pyramid.factories.pyramid_config` provides you with Configuration object based on either settings, config_file argument or by --pc command line option config file.
-* :func:`~pytest_pyramid.factories.pyramid_app` creates a :class:`~webtest.app.TestApp` based on Configurator class instance as returned from fixture passed by name to it.
+* :func:`~pytest_pyramid.factories.pyramid_config` provides you with Configuration object based on either settings, config_file argument, or by --pc command-line option config file.
+* :func:`~pytest_pyramid.factories.pyramid_app` creates a :class:`~webtest.app.TestApp` based on Configurator class instance as returned from fixture passed by name to it. It also accepts additional fixtures that should be loaded before the `pyramid_app`. See the example with `postgresql` below.
 
+.. code-block:: python
 
+    from pytest_postgresql.plugin import postgresql
+    from pytest_pyramid import factories
 
+    app_config = factories.pyramid_config(config_path="development.ini")
+    app_with_postgres = factories.pyramid_app("app_config", "postgresql")
+
+    def test_pyramid_app(app_with_postgres):
+        res = app_with_postgres.get('/', status=404)
+        assert res.status_code == 404

--- a/pytest_pyramid/factories.py
+++ b/pytest_pyramid/factories.py
@@ -59,7 +59,7 @@ def pyramid_config(settings=None, config_path=None):
     return pyramid_config
 
 
-def pyramid_app(config_fixture_name):
+def pyramid_app(config_fixture_name, *additional_fixtures):
     """
     pyramid_app fixture factory.
 
@@ -68,12 +68,17 @@ def pyramid_app(config_fixture_name):
     :param str config_fixture_name: name of a fixture creating
         :class:`pyramid.config.Configurator`
 
+    :param List[str] additional_fixtures: list of any additional
+        fixture names that should be loaded before the pyramid_app fixture.
+
     :returns: TestApp based on pyramid's COnfigurator object as returned from
         fixture passed by  **config_fixture_name**
     :rtype: webtest.app.TestApp
     """
     @pytest.fixture
     def pyramid_app(request):
+        for additional_fixture in additional_fixtures:
+            request.getfixturevalue(additional_fixture)
         config = request.getfixturevalue(config_fixture_name)
 
         app = TestApp(config.make_wsgi_app())

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -1,6 +1,8 @@
 """Testing fixtures."""
-from webtest import TestApp
 from pyramid.config import Configurator
+import pytest
+from webtest import TestApp
+
 from pytest_pyramid import factories
 
 
@@ -73,3 +75,29 @@ def test_pyramid_inheritance_config(
         len(pyramid_config_path.registry.settings) + 1
 
     assert pyramid_config_inheritance.registry.settings['one_value'] == '1'
+
+
+@pytest.fixture()
+def dummy_fixture():
+    """Return dummy fixture that does nothing."""
+
+
+pyramid_app_with_additional_fixtures = factories.pyramid_app(
+    "pyramid_config_path", "dummy_fixture"
+)
+
+
+def test_pyramid_app_with_additional_fixtures(
+    pyramid_app_with_additional_fixtures, request
+):
+    """
+    Test that pyramid_app factory works with additional_fixtures.
+
+    It checks if additional_fixtures are loaded for the test.
+    """
+    assert set(request.fixturenames) == set([
+        'pyramid_app_with_additional_fixtures',
+        'request',
+        'pyramid_config_path',
+        'dummy_fixture'
+    ])


### PR DESCRIPTION
It allows to pass any additional fixtures that should be loaded before
the pyramid_app fixture