### PR TITLE
Add Python 3.15 to the CI - closes #734

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
   tests:
     uses: fizyk/actions-reuse/.github/workflows/shared-tests-pytests.yml@bd825c06829614c809e87acac868a1143328a5b4 # v5.3.2
     with:
-      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]'
       dependency-manager: 'uv'
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/newsfragments/734.misc.rst
+++ b/newsfragments/734.misc.rst
@@ -1,0 +1,1 @@
+Add Python 3.15 to CI


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added Python 3.15 to the continuous integration test matrix.

- **Documentation**
  - Added a release note documenting Python 3.15 support in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->